### PR TITLE
One store to rule them all

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Wrapper around [erlavro](https://github.com/avvo/erlavro) library for Elixir.
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+[Available in Hex](https://hex.pm/packages/avrolixr), the package can be installed as:
 
   1. Add `avrolixr` to your list of dependencies in `mix.exs`:
 

--- a/lib/avrolixr.ex
+++ b/lib/avrolixr.ex
@@ -10,6 +10,7 @@ defmodule Avrolixr do
     children = [
       # Starts a worker by calling: Avrolixr.Worker.start_link(arg1, arg2, arg3)
       # worker(Avrolixr.Worker, [arg1, arg2, arg3]),
+      worker(Avrolixr.Store, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/avrolixr/codec.ex
+++ b/lib/avrolixr/codec.ex
@@ -93,7 +93,7 @@ defmodule Avrolixr.Codec do
   end
 
   defp make_store(schema_json) do
-    :avro_schema_store.import_schema_json(schema_json, :avro_schema_store.new)
+    Avrolixr.Store.import_schema(schema_json)
   end
 
   defp encode_long(long) do

--- a/lib/avrolixr/store.ex
+++ b/lib/avrolixr/store.ex
@@ -1,0 +1,20 @@
+defmodule Avrolixr.Store do
+  require Logger
+  def start_link, do: Agent.start_link(fn -> :avro_schema_store.new end, name: __MODULE__)
+
+  def import_schema(schema_json) do
+    Agent.get_and_update(__MODULE__, fn store ->
+      try do
+        updated_store = :avro_schema_store.import_schema_json(schema_json, store)
+        {updated_store, updated_store}
+      rescue
+        e in ErlangError ->
+          case e do
+            %{original: {:type_with_same_name_already_exists_in_store, _}} -> nil
+            other -> Logger.warn "Attempt to add schema to store failed: #{inspect(other)}"
+          end
+          {store, store}
+      end
+    end)
+  end
+end

--- a/test/avrolixr/store_test.exs
+++ b/test/avrolixr/store_test.exs
@@ -1,0 +1,19 @@
+defmodule Avrolixr.StoreTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  test "import_schema imports json schema to store" do
+    schema_path = "test/data/AvvoProAdded.avsc"
+    {:ok, schema_json} = File.read(schema_path)
+    store = Avrolixr.Store.import_schema(schema_json)
+    assert  {:ok, _} = :avro_schema_store.lookup_type('AvvoEvent.AvvoProAdded', store)
+  end
+
+  test "importing same schema twice doesn't fail" do
+    schema_path = "test/data/AvvoProAdded.avsc"
+    {:ok, schema_json} = File.read(schema_path)
+    store = Avrolixr.Store.import_schema(schema_json)
+    store = Avrolixr.Store.import_schema(schema_json)
+    assert  {:ok, _} = :avro_schema_store.lookup_type('AvvoEvent.AvvoProAdded', store)
+  end
+end


### PR DESCRIPTION
Don't create a new store everytime we encode/decode. Use a single store. But if we already have a type of that name, don't worry, just return the existing store.
