### PR TITLE
Update deps and restrictions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule Avrolixr.Mixfile do
       elixir: "~> 1.3",
       package: package(),
       start_permanent: Mix.env == :prod,
-      version: "0.1.3",
+      version: "0.2.0"
    ]
   end
 
@@ -21,17 +21,18 @@ defmodule Avrolixr.Mixfile do
       applications: [
         :erlavro,
         :mochijson3,
-        :poison,
-      ],
-   ]
+        :poison
+      ]
+    ]
   end
 
   defp deps do
     [
-      {:dialyxir, "~> 0.3.5", only: [:dev]},
       {:erlavro, git: "https://github.com/avvo/erlavro", ref: "fb7c7f0"},
-      {:ex_doc, ">= 0.0.0", only: [:dev]},
       {:poison, "~> 2.0"},
+      # NON-PRODUCTION DEPS
+      {:dialyxir, "~> 0.4", only: [:dev]},
+      {:ex_doc, ">= 0.0.0", only: [:dev]}
     ]
   end
 
@@ -47,8 +48,10 @@ defmodule Avrolixr.Mixfile do
       files: ["lib", "mix.exs", "CHANGELOG.md", "README.md", "LICENSE.txt"],
       maintainers: ["Donald Plummer", "John Fearnside"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/avvo/avrolixr",
-               "Docs" => "https://hexdocs.pm/avrolixr"}
+      links: %{
+        "GitHub" => "https://github.com/avvo/avrolixr",
+        "Docs" => "https://hexdocs.pm/avrolixr"
+      }
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -4,4 +4,4 @@
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "jsonx": {:git, "https://github.com/iskra/jsonx.git", "9c95948c6835827ed61a9506ae4a9aba61acf335", [branch: "master"]},
   "mochijson3": {:git, "https://github.com/tophitpoker/mochijson3.git", "1a1c913ac80bb45d3de5fbd74d21e96c45e9e844", [branch: "master"]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"dialyxir": {:hex, :dialyxir, "0.3.5", "eaba092549e044c76f83165978979f60110dc58dd5b92fd952bf2312f64e9b14", [:mix], []},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+%{"dialyxir": {:hex, :dialyxir, "0.4.1", "236056d6acd25f740f336756c0f3b5dd6e2f0156074bc15f3b779aeee15390c8", [:mix], []},
+  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "erlavro": {:git, "https://github.com/avvo/erlavro", "fb7c7f0b2784468edeea0961984247242097aee5", [ref: "fb7c7f0"]},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "jsonx": {:git, "https://github.com/iskra/jsonx.git", "9c95948c6835827ed61a9506ae4a9aba61acf335", [branch: "master"]},
   "mochijson3": {:git, "https://github.com/tophitpoker/mochijson3.git", "1a1c913ac80bb45d3de5fbd74d21e96c45e9e844", [branch: "master"]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}


### PR DESCRIPTION
So other projects using this library can update.

- Bump minor version restriction for: dialyxir
- Bump minor version
- Restrict only at the minor level
- Alpha order, one per line 